### PR TITLE
feat: Add layout integrity check and documentation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -90,3 +90,36 @@ To avoid incurring costs from GitHub-hosted runners, this project uses a self-ho
 - For architecture, see this file and `/docs`.
 - For linking/asset rules, see [LINKING_GUIDE.md](./LINKING_GUIDE.md).
 - Document new errors in Troubleshooting and/or open an issue.
+
+## Integrating Interactive Components (React, etc.) and Maintaining Layout Structure
+
+This project enforces a consistent page structure: a top header (navigation), a main content area (middle body), and a bottom footer. This is primarily managed by the `src/layouts/Layout.astro` component.
+
+To ensure this structure is maintained and to provide a clear way to add complex or interactive UI elements (e.g., using React, Vue, Svelte, or other client-side frameworks):
+
+1.  **Use the Main Layout:** All pages created under `src/pages/` should use the primary `Layout.astro` component. The `scripts/check-layout-integrity.js` script (part of the pre-commit hook) will verify this.
+
+2.  **Content Goes in the Slot:** The "middle body" of any page is rendered via the `<slot />` tag within `Layout.astro`. All page-specific content, including text, images, Astro components, and framework components (like React components), must be placed *inside* the `<Layout>...</Layout>` tags on a page.
+
+3.  **Embedding Framework Components:**
+    *   Framework components (e.g., a React component like `MyInteractiveWidget.jsx`) should be imported into your Astro components or directly into your Astro page files (`.astro`).
+    *   These components are then used within the Astro component's template, which itself will be part of the content passed to the main `<slot />`.
+    *   **Example:**
+        ```astro
+        // src/pages/my-interactive-page.astro
+        ---
+        import Layout from '@/layouts/Layout.astro';
+        import MyInteractiveWidget from '@/components/MyInteractiveWidget.jsx'; // A React component
+        import RegularAstroComponent from '@/components/RegularAstroComponent.astro';
+        ---
+        <Layout title="My Interactive Page">
+          <h1>Welcome to my interactive page!</h1>
+          <RegularAstroComponent />
+          <MyInteractiveWidget client:load /> {/* client directive for interactivity */}
+          <p>Some more content here...</p>
+        </Layout>
+        ```
+
+4.  **Do Not Modify Core Layout for Content:** Avoid directly altering `src/layouts/Layout.astro` to insert page-specific interactive elements. The `Layout.astro` component is for the global site structure (navigation, main slot, footer). Page-specific content, no matter how complex, belongs in the pages themselves or in components imported by those pages, ultimately rendering within the `<slot />`.
+
+By following these guidelines, we can ensure the site maintains a consistent structural integrity while still allowing for rich, interactive user experiences. The automated checks will help prevent accidental breakage of the main layout.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "google-gemini-codes",
+  "name": "app",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "postbuild": "node src/scripts/generate-trees.js",
-    "precommit": "node scripts/check-protected-files.js"
+    "check-layout": "node scripts/check-layout-integrity.js",
+    "precommit": "node scripts/check-protected-files.js && npm run check-layout"
   },
   "dependencies": {
     "@astrojs/react": "^4.3.0",

--- a/scripts/check-layout-integrity.js
+++ b/scripts/check-layout-integrity.js
@@ -1,0 +1,105 @@
+// scripts/check-layout-integrity.js
+import fs from 'fs/promises';
+import path from 'path';
+import { glob } from 'glob';
+
+const CWD = process.cwd();
+const LAYOUT_PATH = path.join(CWD, 'src/layouts/Layout.astro');
+const PAGES_DIR = path.join(CWD, 'src/pages');
+
+let hasErrors = false;
+
+async function checkLayoutFile() {
+    console.log(`Checking layout file: ${LAYOUT_PATH}`);
+    try {
+        const layoutContent = await fs.readFile(LAYOUT_PATH, 'utf-8');
+        // Refined checks to be less naive about comments
+        // This regex looks for '<tagname' not immediately preceded by '<!--'
+        const navRegex = /(?<!<!--\s*)<nav/;
+        const slotRegex = /(?<!<!--\s*)<slot/; // Handles <slot /> and <slot>
+        const footerRegex = /(?<!<!--\s*)<footer/;
+
+        if (!navRegex.test(layoutContent)) {
+            console.error(`🔴 Error: src/layouts/Layout.astro is missing a <nav> element (or it's commented out).`);
+            hasErrors = true;
+        }
+        // For slot, Astro allows <slot /> or <slot></slot>. The regex `/<slot/` covers both starts.
+        // The original check `!layoutContent.includes('<slot />') && !layoutContent.includes('<slot>')` was actually fine for slot.
+        // Let's stick to a similar regex pattern for consistency, but the original check for slot was okay.
+        if (!slotRegex.test(layoutContent)) {
+            console.error(`🔴 Error: src/layouts/Layout.astro is missing a <slot /> or <slot> element (or it's commented out).`);
+            hasErrors = true;
+        }
+        if (!footerRegex.test(layoutContent)) {
+            console.error(`🔴 Error: src/layouts/Layout.astro is missing a <footer> element (or it's commented out).`);
+            hasErrors = true;
+        }
+        if (!hasErrors) {
+            console.log(`🟢 Layout file src/layouts/Layout.astro passed checks.`);
+        }
+    } catch (error) {
+        console.error(`🔴 Error reading src/layouts/Layout.astro: ${error.message}`);
+        hasErrors = true;
+    }
+}
+
+async function checkPageFile(filePath) {
+    console.log(`Checking page file: ${filePath}`);
+    let pageHasErrors = false;
+    try {
+        const pageContent = await fs.readFile(filePath, 'utf-8');
+        const relativeLayoutPath = path.relative(path.dirname(filePath), LAYOUT_PATH).replace(/\\/g, '/'); // Handle windows paths
+
+        // Check for layout import: import Layout from '...@/layouts/Layout.astro'; or '../layouts/Layout.astro'; etc.
+        // A more robust regex might be needed for complex aliasing or pathing, but this covers common cases.
+        const importRegex = new RegExp(`import\\s+\\w+\\s+from\\s+['"]((@/layouts/Layout\\.astro)|(\\.\\./layouts/Layout\\.astro)|(\\.\\.\\/\\.\\./layouts/Layout\\.astro)|(${relativeLayoutPath}))['"]`);
+        if (!importRegex.test(pageContent)) {
+            console.error(`🔴 Error: ${filePath} does not seem to import Layout.astro.`);
+            pageHasErrors = true;
+            hasErrors = true;
+        }
+
+        // Check for layout usage: <Layout ...> or <Layout>
+        if (!pageContent.includes('<Layout')) {
+            console.error(`🔴 Error: ${filePath} does not seem to use the <Layout> component.`);
+            pageHasErrors = true;
+            hasErrors = true;
+        }
+        if (!pageHasErrors) {
+            console.log(`🟢 Page file ${filePath} passed checks.`);
+        }
+
+    } catch (error) {
+        console.error(`🔴 Error reading or processing ${filePath}: ${error.message}`);
+        hasErrors = true;
+    }
+}
+
+async function main() {
+    console.log('Starting layout integrity check...');
+
+    await checkLayoutFile();
+
+    console.log('\nChecking page files...');
+    const pageFiles = await glob('src/pages/**/*.astro', { cwd: CWD, absolute: true, ignore: ['src/pages/api/**/*.astro'] }); // Assuming api routes might not use Layout
+
+    if (pageFiles.length === 0) {
+        console.warn('🟡 Warning: No page files found in src/pages to check. This might be an issue with the glob pattern or directory structure.');
+    }
+
+    for (const file of pageFiles) {
+        await checkPageFile(file);
+    }
+
+    if (hasErrors) {
+        console.error('\n🔴 Layout integrity check failed with errors.');
+        process.exit(1);
+    } else {
+        console.log('\n🟢 All layout integrity checks passed.');
+    }
+}
+
+main().catch(err => {
+    console.error(`🔴 Unhandled error in script: ${err.message}`);
+    process.exit(1);
+});


### PR DESCRIPTION
- Implemented a Node.js script `scripts/check-layout-integrity.js` to validate Astro page structure.
- The script ensures that all pages in `src/pages/**/*.astro` use the main `src/layouts/Layout.astro`.
- It also verifies that `Layout.astro` contains essential elements: `<nav>`, `<slot />`, and `<footer>`.
- Integrated this script into the `precommit` hook in `package.json` to run checks automatically.
- Added documentation in `DOCUMENTATION.md` guiding the integration of interactive components (e.g., React) while maintaining the core layout structure.