### PR TITLE
feat: Create Accordion component showcase

### DIFF
--- a/src/components/showcase/accordions/ShowcaseAccordion.astro
+++ b/src/components/showcase/accordions/ShowcaseAccordion.astro
@@ -1,0 +1,236 @@
+---
+// src/components/showcase/accordions/ShowcaseAccordion.astro
+interface Props {
+  id?: string;
+  title: string;
+  isOpen?: boolean;
+  iconSet?: 'chevron' | 'plus-minus' | 'custom-svg' | 'none';
+  customIconSvg?: { open: string; closed: string }; // Raw SVG strings
+  iconPosition?: 'left' | 'right';
+  colorScheme?: 'default' | 'dark' | 'vibrant-blue' | 'muted-green' | 'jarring-pink-yellow' | 'functional-gray';
+  borderStyle?: 'full' | 'header-only' | 'none' | 'fancy-shadow' | 'minimal-bottom';
+  animationStyle?: 'default' | 'fast' | 'slow-fade' | 'none';
+  customHeaderClasses?: string;
+  customContentClasses?: string;
+  customIconContainerClasses?: string;
+  customIconClasses?: string;
+}
+
+const {
+  id = `accordion-${Math.random().toString(36).substr(2, 9)}`,
+  title,
+  isOpen = false,
+  iconSet = 'chevron',
+  customIconSvg,
+  iconPosition = 'right',
+  colorScheme = 'default',
+  borderStyle = 'full',
+  animationStyle = 'default',
+  customHeaderClasses = '',
+  customContentClasses = '',
+  customIconContainerClasses = '',
+  customIconClasses = '',
+} = Astro.props;
+
+// Base classes
+let itemBaseClasses = "accordion-item mb-2";
+let headerBaseClasses = "accordion-header flex items-center cursor-pointer";
+let contentBaseClasses = "accordion-content overflow-hidden"; // Added overflow-hidden for smoother transitions
+let titleBaseClasses = "font-semibold flex-grow";
+let iconContainerBaseClasses = "transform transition-transform";
+
+// Animation style
+switch (animationStyle) {
+  case 'fast':
+    iconContainerBaseClasses += " duration-150";
+    contentBaseClasses += " transition-all duration-150 ease-out";
+    break;
+  case 'slow-fade':
+    iconContainerBaseClasses += " duration-500";
+    contentBaseClasses += " transition-all duration-500 ease-in-out"; // opacity can be added if desired
+    break;
+  case 'none':
+    iconContainerBaseClasses = ""; // No transform for no animation
+    contentBaseClasses += "";
+    break;
+  default: // 'default'
+    iconContainerBaseClasses += " duration-300";
+    contentBaseClasses += " transition-all duration-300 ease-out";
+    break;
+}
+
+// Color Scheme classes
+switch (colorScheme) {
+  case 'dark':
+    itemBaseClasses += " bg-slate-700 text-white";
+    headerBaseClasses += " p-4 hover:bg-slate-600";
+    titleBaseClasses += " text-slate-100";
+    contentBaseClasses += " p-4 bg-slate-600 border-slate-500";
+    // icon color implied by text-white or can be specific
+    break;
+  case 'vibrant-blue':
+    itemBaseClasses += " bg-blue-600 text-white";
+    headerBaseClasses += " p-4 hover:bg-blue-700";
+    titleBaseClasses += " text-white";
+    contentBaseClasses += " p-4 bg-blue-500 border-blue-400";
+    break;
+  case 'muted-green':
+    itemBaseClasses += " bg-green-100 text-green-800";
+    headerBaseClasses += " p-4 hover:bg-green-200";
+    titleBaseClasses += " text-green-900";
+    contentBaseClasses += " p-4 bg-green-50 border-green-200";
+    break;
+  case 'jarring-pink-yellow':
+    itemBaseClasses += " bg-yellow-300 text-pink-700";
+    headerBaseClasses += " p-4 hover:bg-yellow-400";
+    titleBaseClasses += " text-pink-700 font-bold";
+    contentBaseClasses += " p-4 bg-pink-100 border-pink-300";
+    break;
+  case 'functional-gray':
+    itemBaseClasses += " bg-gray-200 text-gray-800";
+    headerBaseClasses += " p-4 hover:bg-gray-300";
+    titleBaseClasses += " text-gray-900";
+    contentBaseClasses += " p-4 bg-gray-100 border-gray-300";
+    break;
+  default: // 'default'
+    itemBaseClasses += " bg-white dark:bg-slate-800 text-gray-800 dark:text-slate-200";
+    headerBaseClasses += " p-4 hover:bg-gray-50 dark:hover:bg-slate-700";
+    // titleBaseClasses += " text-gray-800 dark:text-slate-100"; // already part of default
+    contentBaseClasses += " p-4 bg-gray-50 dark:bg-slate-700 border-gray-200 dark:border-slate-600";
+    break;
+}
+
+// Border style classes
+switch (borderStyle) {
+  case 'full':
+    itemBaseClasses += " border rounded-lg border-gray-300 dark:border-slate-600";
+    contentBaseClasses += " border-t"; // Already added by color scheme or default
+    break;
+  case 'header-only':
+    itemBaseClasses += " rounded-t-lg"; // Rounded top for item
+    headerBaseClasses += " border-b border-gray-300 dark:border-slate-600";
+    contentBaseClasses += ""; // No extra border for content, relies on header's bottom border
+    break;
+  case 'minimal-bottom':
+    headerBaseClasses += " border-b border-gray-200 dark:border-slate-700";
+    // no item border
+    break;
+  case 'fancy-shadow':
+    itemBaseClasses += " rounded-lg shadow-xl";
+     // contentBaseClasses += " border-t"; // Optional, depending on look
+    break;
+  case 'none':
+    // No border classes added to item or content
+    break;
+}
+
+
+const headerFlexDirection = iconPosition === 'left' ? 'flex-row-reverse' : 'flex-row';
+if (iconPosition === 'left') titleBaseClasses += " text-right";
+
+// Initial state for content visibility and icon rotation
+const initialContentClasses = isOpen ? "" : "max-h-0 opacity-0"; // Use max-h for transition
+const initialIconRotation = isOpen && iconSet !== 'none' && animationStyle !== 'none' ? "rotate-180" : "";
+
+---
+<div class={`${itemBaseClasses}`}>
+    <div
+        class:list={[headerBaseClasses, headerFlexDirection, customHeaderClasses]}
+        aria-expanded={isOpen.toString()}
+        aria-controls={id + "-content"}
+        data-accordion-header-for={id}
+    >
+        <h3 class:list={[titleBaseClasses]}>{title}</h3>
+        {iconSet !== 'none' && (
+            <span class:list={[iconContainerBaseClasses, initialIconRotation, customIconContainerClasses]}>
+                {iconSet === 'chevron' && <i class:list={["fas fa-chevron-down", customIconClasses]}></i>}
+                {iconSet === 'plus-minus' && <span class:list={["plus-minus-icon", customIconClasses]}>{isOpen ? '-' : '+'}</span>}
+                {iconSet === 'custom-svg' && customIconSvg && (
+                    <Fragment set:html={isOpen ? customIconSvg.open : customIconSvg.closed} />
+                )}
+            </span>
+        )}
+    </div>
+    <div
+        id={id + "-content"}
+        class:list={[contentBaseClasses, initialContentClasses, customContentClasses]}
+        aria-labelledby={id + "-header"}
+    >
+        <div class="inner-content py-1"> <!-- Added padding to inner content div for better appearance during animation -->
+            <slot />
+        </div>
+    </div>
+</div>
+
+<script define:vars={{ iconSet }}>
+    // Making the script more robust and specific to each accordion instance
+    // Using data attributes to link header to content for multiple accordions on a page.
+
+    function toggleAccordion(headerElement) {
+        const accordionId = headerElement.dataset.accordionHeaderFor;
+        if (!accordionId) return;
+
+        const content = document.getElementById(accordionId + "-content");
+        const iconContainer = headerElement.querySelector('span[class*="transform"]'); // More specific selector
+        const plusMinusIcon = headerElement.querySelector('span.plus-minus-icon');
+
+        const isOpen = content.classList.contains('max-h-screen'); // Check based on a class that indicates open
+
+        if (isOpen) {
+            content.classList.remove('max-h-screen', 'opacity-100');
+            content.classList.add('max-h-0', 'opacity-0');
+            headerElement.setAttribute('aria-expanded', 'false');
+            if (iconContainer) iconContainer.classList.remove('rotate-180');
+            if (plusMinusIcon) plusMinusIcon.textContent = '+';
+            // Custom SVG state change would need more complex handling if SVGs are not swapped by Astro
+        } else {
+            content.classList.remove('max-h-0', 'opacity-0');
+            content.classList.add('max-h-screen', 'opacity-100'); // Use a large max-h value
+            headerElement.setAttribute('aria-expanded', 'true');
+            if (iconContainer) iconContainer.classList.add('rotate-180');
+            if (plusMinusIcon) plusMinusIcon.textContent = '-';
+        }
+    }
+
+    // Initialize accordions based on their isOpen prop (for server-rendered state)
+    // and set up click listeners
+    document.querySelectorAll('[data-accordion-header-for]').forEach(header => {
+        const accordionId = header.dataset.accordionHeaderFor;
+        const content = document.getElementById(accordionId + "-content");
+        const isInitiallyOpen = header.getAttribute('aria-expanded') === 'true';
+
+        if (content) {
+            if (isInitiallyOpen) {
+                 content.classList.remove('max-h-0', 'opacity-0');
+                 content.classList.add('max-h-screen', 'opacity-100'); // Ensure it's visually open
+            } else {
+                 content.classList.add('max-h-0', 'opacity-0'); // Ensure it's visually closed
+            }
+        }
+
+        header.addEventListener('click', () => toggleAccordion(header));
+    });
+</script>
+
+<style is:global>
+    /* Add Font Awesome if using chevron and it's not globally available */
+    /* @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css'); */
+
+    .accordion-content {
+        /* Default to collapsed state for transition */
+        /* max-height: 0; */
+        /* opacity: 0; */
+        /* overflow: hidden; */ /* Already added to base class */
+    }
+    .accordion-content.max-h-screen { /* Arbitrary large value for open state */
+        max-height: 100vh; /* Adjust as needed, or use JS to set to scrollHeight */
+        /* opacity: 1; */
+    }
+
+    .plus-minus-icon {
+        display: inline-block;
+        width: 1.25em; /* Adjust as needed */
+        text-align: center;
+        font-weight: bold;
+    }
+</style>

--- a/src/layouts/ShowcaseLayout.astro
+++ b/src/layouts/ShowcaseLayout.astro
@@ -1,0 +1,59 @@
+---
+// src/layouts/ShowcaseLayout.astro
+import '../styles/global.css'; // Assuming you want to use existing global styles
+import BaseLink from '@/components/BaseLink.astro'; // Reusing existing BaseLink for consistency
+
+interface Props {
+	title: string;
+	showcaseItemName?: string; // e.g., "Accordions"
+}
+
+const { title, showcaseItemName } = Astro.props;
+const base = Astro.site ? new URL(Astro.url.pathname, Astro.site).pathname.split('/')[1] : '';
+const showcaseHomePath = `/${base ? base + '/' : ''}showcase`;
+const itemGalleryPath = showcaseItemName ? `${showcaseHomePath}/${showcaseItemName.toLowerCase()}` : '';
+---
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="description" content={`Showcase: ${title}`} />
+	<meta name="viewport" content="width=device-width" />
+	<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+	<meta name="generator" content={Astro.generator} />
+	<title>{title} | Component Showcase</title>
+</head>
+<body class="bg-slate-100 dark:bg-slate-900 text-slate-800 dark:text-slate-200">
+	<header class="bg-slate-200 dark:bg-slate-800 shadow-md">
+		<nav class="container mx-auto px-6 py-3 flex justify-between items-center">
+			<div>
+				<a href={showcaseHomePath} class="text-xl font-bold hover:text-blue-600 dark:hover:text-blue-400">Component Showcase</a>
+			</div>
+			<div class="flex space-x-4">
+				<BaseLink href={Astro.site?.pathname === '/' ? '/' : `/${base}`}>Main Site Home</BaseLink>
+				<BaseLink href={showcaseHomePath}>Showcase Home</BaseLink>
+				{showcaseItemName && itemGalleryPath && (
+					<BaseLink href={itemGalleryPath}>{showcaseItemName} Gallery</BaseLink>
+				)}
+			</div>
+		</nav>
+	</header>
+
+	<main class="container mx-auto px-6 py-8">
+		<h1 class="text-3xl font-bold mb-6 text-center header-text">{title}</h1>
+		<div class="bg-white dark:bg-slate-800 shadow-xl rounded-lg p-6 min-h-[calc(100vh-20rem)]">
+			<slot />
+		</div>
+	</main>
+
+	<footer class="text-center py-8 mt-12 border-t border-slate-300 dark:border-slate-700">
+		<p class="text-sm text-slate-600 dark:text-slate-400">&copy; {new Date().getFullYear()} Showcase Area</p>
+	</footer>
+</body>
+</html>
+<style>
+	/* Basic styles for showcase if needed, complementing global.css */
+	body {
+		font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+	}
+</style>

--- a/src/pages/showcase/accordions/index.astro
+++ b/src/pages/showcase/accordions/index.astro
@@ -1,0 +1,44 @@
+---
+// src/pages/showcase/accordions/index.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import BaseLink from '@/components/BaseLink.astro';
+
+// This list will be populated as variations are created
+const accordionVariations = [
+  { title: "Variation 1: Default Style", url: "/showcase/accordions/variation-1", description: "Replicates the original component's look and feel." },
+  { title: "Variation 2: Dark Mode Theme", url: "/showcase/accordions/variation-2", description: "Accordion styled for dark backgrounds." },
+  { title: "Variation 3: Minimalist Style", url: "/showcase/accordions/variation-3", description: "Clean design with minimal borders and plus/minus icons." },
+  { title: "Variation 4: Vibrant Blue Theme", url: "/showcase/accordions/variation-4", description: "Uses a strong blue for headers/accents." },
+  { title: "Variation 5: Muted Green Theme", url: "/showcase/accordions/variation-5", description: "Soft green tones for a calm feel." },
+  { title: "Variation 6: Icon on Left", url: "/showcase/accordions/variation-6", description: "Toggle icon positioned to the left of the title." },
+  { title: "Variation 7: No Icons", url: "/showcase/accordions/variation-7", description: "Accordion without any open/close indicator icons." },
+  { title: "Variation 8: Fancy Shadow Border", url: "/showcase/accordions/variation-8", description: "Uses shadows instead of lines for item separation." },
+  { title: "Variation 9: Jarring Pink/Yellow", url: "/showcase/accordions/variation-9", description: "A high-contrast, vibrant, and potentially 'jarring' theme." },
+  { title: "Variation 10: Custom SVG Icons", url: "/showcase/accordions/variation-10", description: "Demonstrates using custom inline SVGs for icons." },
+  { title: "Variation 11: Image & Text Content", url: "/showcase/accordions/variation-11", description: "Shows an accordion handling mixed media (image and text)." },
+  { title: "Variation 12: Nested Accordions", url: "/showcase/accordions/variation-12", description: "Accordions placed within other accordions." },
+];
+---
+<ShowcaseLayout title="Accordion Component Showcase" showcaseItemName="Accordions">
+    <p class="mb-6 text-center">
+        This gallery showcases various implementations and styles of the Accordion component.
+        Each variation explores different visual themes, minor functional tweaks, or content presentations.
+    </p>
+
+    {accordionVariations.length > 0 ? (
+        <div class="space-y-4">
+            {accordionVariations.map(variation => (
+                <div class="bg-slate-50 dark:bg-slate-700 p-4 rounded-lg shadow hover:shadow-lg transition-shadow">
+                    <BaseLink href={variation.url} class="text-lg font-semibold text-blue-700 dark:text-blue-400 hover:underline">
+                        {variation.title}
+                    </BaseLink>
+                    <p class="text-sm text-slate-600 dark:text-slate-300 mt-1">{variation.description}</p>
+                </div>
+            ))}
+        </div>
+    ) : (
+        <p class="text-center text-slate-500 dark:text-slate-400">
+            Accordion variations will be listed here once created.
+        </p>
+    )}
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-1.astro
+++ b/src/pages/showcase/accordions/variation-1.astro
@@ -1,0 +1,26 @@
+---
+// src/pages/showcase/accordions/variation-1.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+---
+<ShowcaseLayout title="Accordion: Variation 1 - Default Style" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        This variation aims to replicate the original styling and functionality of the accordion component from <code>.unused/Accordion.astro</code> using the new reusable <code>ShowcaseAccordion.astro</code> component.
+    </p>
+
+    <ShowcaseAccordion title="Default Accordion Item 1" isOpen={true}>
+        <p>This is the content for the first accordion item. It is open by default. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion title="Default Accordion Item 2">
+        <p>This is the content for the second accordion item. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+        <ul class="list-disc pl-5 mt-2">
+            <li>Point one</li>
+            <li>Point two</li>
+        </ul>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion title="Default Accordion Item 3">
+        <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-10.astro
+++ b/src/pages/showcase/accordions/variation-10.astro
@@ -1,0 +1,45 @@
+---
+// src/pages/showcase/accordions/variation-10.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+
+// Define some simple SVG strings for open/closed states
+const customSvgIcons = {
+    open: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-folder-minus"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L8.6 3.3a2 2 0 0 0-1.69-.9H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"></path><line x1="9" x2="15" y1="14" y2="14"></line></svg>',
+    closed: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-folder-plus"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L8.6 3.3a2 2 0 0 0-1.69-.9H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"></path><line x1="12" x2="12" y1="10" y2="16"></line><line x1="9" x2="15" y1="13" y2="13"></line></svg>'
+};
+---
+<ShowcaseLayout title="Accordion: Variation 10 - Custom SVG Icons" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        This variation demonstrates using custom inline SVG strings for the open and close indicator icons.
+    </p>
+
+    <ShowcaseAccordion
+        title="Accordion with Custom SVG Folder Icons"
+        isOpen={false}
+        iconSet="custom-svg"
+        customIconSvg={customSvgIcons}
+        iconPosition="left"
+        colorScheme="functional-gray"
+        borderStyle="full"
+        customIconContainerClasses="mr-2 w-6 h-6"
+    >
+        <p>The icon for this accordion is a custom SVG (a folder icon that changes from plus to minus). This allows for complete control over the icon's appearance.</p>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion
+        title="Another Custom SVG Example"
+        isOpen={true}
+        iconSet="custom-svg"
+        customIconSvg={{
+            open: '<svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>',
+            closed: '<svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>'
+        }}
+        iconPosition="right"
+        colorScheme="default"
+        borderStyle="minimal-bottom"
+        customIconContainerClasses="w-5 h-5"
+    >
+        <p>This one uses simple up/down arrow SVGs.</p>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-11.astro
+++ b/src/pages/showcase/accordions/variation-11.astro
@@ -1,0 +1,30 @@
+---
+// src/pages/showcase/accordions/variation-11.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+// Assuming a placeholder image might be in public/images or use an external one
+const placeholderImageUrl = "https://via.placeholder.com/300x200.png?text=Sample+Image";
+---
+<ShowcaseLayout title="Accordion: Variation 11 - Image & Text Content" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        This variation shows how an accordion item can handle mixed content, like an image alongside text, within its slot.
+    </p>
+
+    <ShowcaseAccordion title="Item with Featured Image" isOpen={true} colorScheme="default" borderStyle="fancy-shadow">
+        <div class="flex flex-col md:flex-row gap-4 items-start">
+            <img src={placeholderImageUrl} alt="Placeholder Image" class="w-full md:w-1/3 rounded shadow-md"/>
+            <div class="flex-grow">
+                <h4 class="font-semibold text-lg mb-2">Image Title or Sub-heading</h4>
+                <p>This content area includes a placeholder image and accompanying text. Accordions can be versatile in displaying various types of media and information layouts.</p>
+                <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">Image dimensions and text flow can be controlled using standard HTML and CSS within the slot.</p>
+            </div>
+        </div>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion title="Another Mixed Content Example" colorScheme="functional-gray">
+        <p>Simple text can be combined with more complex layouts if needed.</p>
+        <blockquote class="mt-2 p-2 border-l-4 border-gray-400 bg-gray-100 dark:bg-gray-700 dark:border-gray-500">
+            "This is a blockquote within an accordion, for example."
+        </blockquote>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-12.astro
+++ b/src/pages/showcase/accordions/variation-12.astro
@@ -1,0 +1,31 @@
+---
+// src/pages/showcase/accordions/variation-12.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+---
+<ShowcaseLayout title="Accordion: Variation 12 - Nested Accordions" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        This demonstrates nesting accordions. The main accordion item's content slot contains another instance of the <code>ShowcaseAccordion</code>.
+    </p>
+
+    <ShowcaseAccordion title="Outer Accordion - Level 1" isOpen={true} colorScheme="default" borderStyle="full">
+        <p class="mb-2">This is the content of the first level accordion. Below is a nested accordion set:</p>
+
+        <div class="ml-4 border-l-2 border-blue-500 pl-4">
+            <ShowcaseAccordion title="Nested Accordion - Level 2.1" colorScheme="muted-green" iconSet="plus-minus" borderStyle="minimal-bottom">
+                <p>Content for nested item 2.1. This shows that accordions can be placed within each other to create hierarchical collapsible sections.</p>
+            </ShowcaseAccordion>
+
+            <ShowcaseAccordion title="Nested Accordion - Level 2.2" colorScheme="muted-green" iconSet="plus-minus" borderStyle="minimal-bottom">
+                <p>Content for nested item 2.2. Each nested accordion maintains its own state independently.</p>
+                <ShowcaseAccordion title="Even Deeper - Level 3.1" colorScheme="functional-gray" iconSet="chevron" iconPosition="left" borderStyle="none" customHeaderClasses="text-sm py-1" customContentClasses="text-xs pl-3 py-1">
+                    <p>Tiny details at level 3!</p>
+                </ShowcaseAccordion>
+            </ShowcaseAccordion>
+        </div>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion title="Another Outer Accordion Item" colorScheme="default" borderStyle="full">
+        <p>Standard content for another top-level item, to show it operates independently of the one with nested items.</p>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-2.astro
+++ b/src/pages/showcase/accordions/variation-2.astro
@@ -1,0 +1,20 @@
+---
+// src/pages/showcase/accordions/variation-2.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+---
+<ShowcaseLayout title="Accordion: Variation 2 - Dark Mode Theme" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        This variation demonstrates the accordion with a 'dark' color scheme. The component itself handles the appropriate text and background colors for a dark theme.
+    </p>
+
+    <div class="p-4 rounded"><!-- Optional: Add a contrasting background for the page if ShowcaseLayout doesn't force one -->
+        <ShowcaseAccordion title="Dark Theme Accordion Item 1" isOpen={true} colorScheme="dark">
+            <p>Content for the first dark accordion item. It is open by default. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </ShowcaseAccordion>
+
+        <ShowcaseAccordion title="Dark Theme Accordion Item 2" colorScheme="dark">
+            <p>Content for the second dark accordion item. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+        </ShowcaseAccordion>
+    </div>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-3.astro
+++ b/src/pages/showcase/accordions/variation-3.astro
@@ -1,0 +1,33 @@
+---
+// src/pages/showcase/accordions/variation-3.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+---
+<ShowcaseLayout title="Accordion: Variation 3 - Minimalist Style" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        This variation showcases a minimalist accordion style: no item borders, minimal padding (handled by custom classes or specific props if implemented), and plus/minus icons.
+    </p>
+
+    <ShowcaseAccordion
+        title="Minimal Accordion - Section 1"
+        isOpen={true}
+        colorScheme="default"
+        borderStyle="minimal-bottom"
+        iconSet="plus-minus"
+        customHeaderClasses="py-2"
+        customContentClasses="py-2 pl-2"
+    >
+        <p>This is content for the first minimalist accordion item. It focuses on clean typography and less visual clutter.</p>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion
+        title="Minimal Accordion - Section 2"
+        colorScheme="default"
+        borderStyle="minimal-bottom"
+        iconSet="plus-minus"
+        customHeaderClasses="py-2"
+        customContentClasses="py-2 pl-2"
+    >
+        <p>Another section in the minimalist style. The separation is primarily achieved by the header's bottom border and typography.</p>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-4.astro
+++ b/src/pages/showcase/accordions/variation-4.astro
@@ -1,0 +1,18 @@
+---
+// src/pages/showcase/accordions/variation-4.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+---
+<ShowcaseLayout title="Accordion: Variation 4 - Vibrant Blue Theme" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        This variation demonstrates a vibrant blue color scheme, suitable for a more modern or branded look.
+    </p>
+
+    <ShowcaseAccordion title="Vibrant Blue - Item 1" isOpen={true} colorScheme="vibrant-blue">
+        <p>Content for the first vibrant blue accordion item. The header has a strong blue background with light text.</p>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion title="Vibrant Blue - Item 2" colorScheme="vibrant-blue">
+        <p>The content area also reflects the theme. This style can be useful for call-to-action sections or primary feature highlights.</p>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-5.astro
+++ b/src/pages/showcase/accordions/variation-5.astro
@@ -1,0 +1,18 @@
+---
+// src/pages/showcase/accordions/variation-5.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+---
+<ShowcaseLayout title="Accordion: Variation 5 - Muted Green Theme" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        This variation uses soft, muted green tones for a calm and organic feel.
+    </p>
+
+    <ShowcaseAccordion title="Muted Green - Info Section" isOpen={true} colorScheme="muted-green">
+        <p>This style is suitable for informational content where a less intrusive design is preferred. Lorem ipsum dolor sit amet.</p>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion title="Muted Green - Further Details" colorScheme="muted-green">
+        <p>The subtle color changes help differentiate sections without being overwhelming. Ut enim ad minim veniam.</p>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-6.astro
+++ b/src/pages/showcase/accordions/variation-6.astro
@@ -1,0 +1,18 @@
+---
+// src/pages/showcase/accordions/variation-6.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+---
+<ShowcaseLayout title="Accordion: Variation 6 - Icon on Left" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        This variation demonstrates placing the toggle icon (chevron by default) on the left side of the accordion header.
+    </p>
+
+    <ShowcaseAccordion title="Icon Left - Item A" isOpen={true} iconPosition="left">
+        <p>The chevron icon now appears to the left of the title. The title text aligns next to it.</p>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion title="Icon Left - Item B (Plus/Minus)" iconPosition="left" iconSet="plus-minus">
+        <p>This also works with the 'plus-minus' icon set, aligning the +/- symbol to the left.</p>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-7.astro
+++ b/src/pages/showcase/accordions/variation-7.astro
@@ -1,0 +1,18 @@
+---
+// src/pages/showcase/accordions/variation-7.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+---
+<ShowcaseLayout title="Accordion: Variation 7 - No Icons" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        A very clean version of the accordion that omits any visual open/close indicator icons. Interaction relies solely on clicking the header.
+    </p>
+
+    <ShowcaseAccordion title="No Icon - Question 1" isOpen={true} iconSet="none" borderStyle="minimal-bottom">
+        <p>This accordion item has no icon. The header itself is the clickable target to toggle content visibility.</p>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion title="No Icon - Question 2" iconSet="none" borderStyle="minimal-bottom">
+        <p>This approach can be useful for FAQs or other content where icons might be considered visual noise.</p>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-8.astro
+++ b/src/pages/showcase/accordions/variation-8.astro
@@ -1,0 +1,18 @@
+---
+// src/pages/showcase/accordions/variation-8.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+---
+<ShowcaseLayout title="Accordion: Variation 8 - Fancy Shadow" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        This variation uses the 'fancy-shadow' border style, where the accordion item is distinguished by a prominent shadow rather than lines.
+    </p>
+
+    <ShowcaseAccordion title="Shadowed Item One" isOpen={true} borderStyle="fancy-shadow" colorScheme="default">
+        <p>The item floats with a shadow. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion title="Shadowed Item Two" borderStyle="fancy-shadow" colorScheme="functional-gray" customHeaderClasses="font-mono" customContentClasses="text-sm">
+        <p>Another item with the fancy shadow style, perhaps with a slightly different internal color scheme or typography for contrast.</p>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/accordions/variation-9.astro
+++ b/src/pages/showcase/accordions/variation-9.astro
@@ -1,0 +1,18 @@
+---
+// src/pages/showcase/accordions/variation-9.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import ShowcaseAccordion from '@/components/showcase/accordions/ShowcaseAccordion.astro';
+---
+<ShowcaseLayout title="Accordion: Variation 9 - Jarring Pink/Yellow" showcaseItemName="Accordions">
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+        Exploring a "jarring" color combination as requested, to push stylistic boundaries. This uses a pink and yellow theme.
+    </p>
+
+    <ShowcaseAccordion title="WARNING: Bright Colors Ahead!" isOpen={true} colorScheme="jarring-pink-yellow" iconSet="plus-minus">
+        <p>This accordion uses a high-contrast, potentially jarring pink and yellow color scheme. Viewer discretion advised!</p>
+    </ShowcaseAccordion>
+
+    <ShowcaseAccordion title="Are Your Eyes Ready?" colorScheme="jarring-pink-yellow" iconSet="plus-minus">
+        <p>Another item in this vibrant, attention-grabbing style. This could be used for specific alerts or unique branding moments.</p>
+    </ShowcaseAccordion>
+</ShowcaseLayout>

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -1,0 +1,21 @@
+---
+// src/pages/showcase/index.astro
+import ShowcaseLayout from '@/layouts/ShowcaseLayout.astro';
+import BaseLink from '@/components/BaseLink.astro';
+---
+<ShowcaseLayout title="Component Showcase Home">
+    <div class="text-center">
+        <p class="mb-4">Welcome to the component showcase area!</p>
+        <p class="mb-8">Here you can find various components and design iterations.</p>
+
+        <h2 class="text-2xl font-semibold mb-4 header-text">Available Showcases:</h2>
+        <ul class="list-none p-0 space-y-2">
+            <li>
+                <BaseLink href="/showcase/accordions" class="text-blue-600 dark:text-blue-400 hover:underline text-lg">
+                    Accordion Component Variations
+                </BaseLink>
+            </li>
+            <!-- More showcases will be listed here -->
+        </ul>
+    </div>
+</ShowcaseLayout>

--- a/src/pages/sitemap.astro
+++ b/src/pages/sitemap.astro
@@ -30,6 +30,8 @@ const otherItems = [
   { title: 'README (Markdown)', url: '/README.md' },
   { title: 'Full Documentation (Markdown)', url: '/DOCUMENTATION.md' },
   { title: 'Linking Guide', url: '/LINKING_GUIDE.md' },
+  { title: 'Component Showcase Home', url: '/showcase' },
+  { title: 'Accordion Showcase Gallery', url: '/showcase/accordions' },
 ];
 ---
 <CommonImports>


### PR DESCRIPTION
- Implemented Phase A, B, and C (initial part) for showcasing variations of an Accordion component sourced from `.unused/Accordion.astro`.

- Created a new `ShowcaseLayout.astro` for dedicated showcase area styling and navigation.
- Established showcase routing with a main showcase page (`src/pages/showcase/index.astro`) and a gallery for accordions (`src/pages/showcase/accordions/index.astro`).

- Developed a flexible `ShowcaseAccordion.astro` component in `src/components/showcase/accordions/` with multiple props to control:
    - Color schemes (default, dark, vibrant-blue, muted-green, jarring-pink-yellow, functional-gray)
    - Icon sets (chevron, plus-minus, custom SVG, none) and position
    - Border styles (full, header-only, minimal-bottom, fancy-shadow, none)
    - Basic animation styles
    - Custom CSS classes for fine-tuning.
    - Enhanced client-side script for independent accordion operation and CSS transitions.

- Created 12 distinct accordion variation pages (`src/pages/showcase/accordions/variation-*.astro`) demonstrating different combinations of styles, icons, themes, and content handling (including nested accordions and image content).
- Updated the accordion gallery page to list and link to all 12 variations with descriptions.
- Updated `src/pages/sitemap.astro` to include links to the new showcase home and accordion gallery.

- Conceptually tested the navigation flow, prop configurations for variations, and client-side script logic.

This provides the first installment of the 'extreme showcase' minisite, starting with accordions.